### PR TITLE
pecify which environments your software should be built for (os/ws/arch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,25 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <version>${tycho.version}</version>
+                <!--Specify which environments your software should be built for (os/ws/arch)  -->
                 <configuration>
+                    <environments>¬
+                        <environment>¬
+                            <os>win32</os>¬
+                            <ws>win32</ws>¬
+                            <arch>x86_64</arch>¬
+                        </environment>¬
+                        <environment>¬
+                            <os>linux</os>¬
+                            <ws>gtk</ws>¬
+                            <arch>x86_64</arch>¬
+                        </environment>¬
+                        <environment>¬
+                            <os>macosx</os>¬
+                            <ws>cocoa</ws>¬
+                            <arch>x86_64</arch>¬
+                        </environment>¬
+                    </environments>¬
                     <target>
                         <artifact>
                             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
if not set the build will warn:
"No explicit target runtime environment configuration. Build is platform dependent"
see: http://wiki.eclipse.org/Tycho/Reference_Card#Target_runtime_environment
