### PR TITLE
upgrade tycho as the 0.18.0 is not compatible with maven 3.1.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho.version>0.18.0</tycho.version>
+        <tycho.version>0.18.1</tycho.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <encoding>UTF-8</encoding>


### PR DESCRIPTION
when running against : maven 3.1.0
you get the following error:
initializationError(org.eclipse.tycho.core.test.DefaultBundleReaderTest): org/sonatype/aether/RepositorySystemSession

bug link: https://bugs.eclipse.org/bugs/show_bug.cgi?id=406056

change the tycho version from 0.18.0 to 0.18.1
